### PR TITLE
Add Maven dependency caching instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,30 @@ docker compose up --build
 ```
 
 The backend will be available at <http://localhost:8080> and the frontend at <http://localhost:3000>.
+
+## Preparing Maven Dependencies
+
+For environments without internet access or simply to speed up builds, you can
+pre-populate a local Maven repository with all required artifacts.
+
+### Using Maven directly
+
+```bash
+cd backend
+mvn -B dependency:go-offline
+```
+
+The above command will download dependencies into your local `~/.m2` directory.
+Subsequent builds will reuse those artifacts even when offline.
+
+### Using the provided script
+
+Run the helper script to cache dependencies inside a local `maven_cache` folder
+using a Docker container:
+
+```bash
+./scripts/preload-maven-deps.sh
+```
+
+You can then point Maven at this directory with `-Dmaven.repo.local=maven_cache`
+when building the project or adapting the `Dockerfile.backend`.

--- a/scripts/preload-maven-deps.sh
+++ b/scripts/preload-maven-deps.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Preload Maven dependencies into a local repository
+#
+# This script uses the official Maven Docker image to download all
+# dependencies defined in the backend module. The artifacts are cached
+# under the `maven_cache` directory so subsequent builds can run
+# without fetching packages from the internet.
+
+set -e
+
+CACHE_DIR="$(pwd)/maven_cache"
+mkdir -p "$CACHE_DIR"
+
+# Run Maven in a Docker container with a bind mount for the cache
+# and the backend source.
+docker run --rm -v "$CACHE_DIR":/root/.m2 \
+    -v "$(pwd)/backend":/app -w /app maven:3.9-eclipse-temurin-21 \
+    mvn -B dependency:go-offline
+
+echo "Dependencies cached in $CACHE_DIR"


### PR DESCRIPTION
## Summary
- explain how to preload Maven dependencies in README
- provide `scripts/preload-maven-deps.sh` script for caching deps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857fe590db0832ab343fd58ba225ff6